### PR TITLE
feat(traits,user): eager loading for checks (#112)

### DIFF
--- a/src/Traits/UsersTrait.php
+++ b/src/Traits/UsersTrait.php
@@ -97,14 +97,13 @@ trait UsersTrait
         } elseif ($permission instanceof $model) {
             $where = ['slug', $permission->slug];
         }
-        
+
         if ($permission != null && $where != null) {
             return (bool) ($this->permissions->where(...$where)->count());
         }
 
         return false;
     }
-
 
     /**
      * Determine if the user has a group which has the required permission.

--- a/src/Traits/UsersTrait.php
+++ b/src/Traits/UsersTrait.php
@@ -32,7 +32,7 @@ trait UsersTrait
     }
 
     /**
-     * Determine if a user has the specified group
+     * Determine if a user has the specified group.
      * @param mixed $group
      * @return bool
      */
@@ -40,9 +40,9 @@ trait UsersTrait
     {
         if (is_numeric($group)) {
             $where = ['id', $group];
-        } else if (is_string($group)) {
+        } elseif (is_string($group)) {
             $where = ['slug', $group];
-        } else if ($group instanceof Group) {
+        } elseif ($group instanceof Group) {
             $where = ['slug', $group->slug];
         }
 
@@ -54,7 +54,7 @@ trait UsersTrait
     }
 
     /**
-     * Determine if a user has a permission, regardless of whether it is direct or via group
+     * Determine if a user has a permission, regardless of whether it is direct or via group.
      * @param $permission
      * @return bool
      */
@@ -62,13 +62,13 @@ trait UsersTrait
     {
         if (is_numeric($permission)) {
             $where = ['id', $permission];
-        } else if (is_string($permission)) {
+        } elseif (is_string($permission)) {
             $where = ['slug', $permission];
-        } else if ($permission instanceof Permission) {
+        } elseif ($permission instanceof Permission) {
             $where = ['slug', $permission->slug];
         }
 
-        if($permission != null) {
+        if ($permission != null) {
             return (bool) ($this->permissions->where(...$where)->count())
                 || $this->hasPermissionThroughGroup($permission);
         }
@@ -77,7 +77,7 @@ trait UsersTrait
     }
 
     /**
-     * Determine if a user has a permission directly associated
+     * Determine if a user has a permission directly associated.
      * @param $permission
      * @return bool
      */
@@ -85,13 +85,13 @@ trait UsersTrait
     {
         if (is_numeric($permission)) {
             $where = ['id', $permission];
-        } else if (is_string($permission)) {
+        } elseif (is_string($permission)) {
             $where = ['slug', $permission];
-        } else if ($permission instanceof Permission) {
+        } elseif ($permission instanceof Permission) {
             $where = ['slug', $permission->slug];
         }
         
-        if($permission != null) {
+        if ($permission != null) {
             return (bool) ($this->permissions->where(...$where)->count());
         }
 
@@ -100,7 +100,7 @@ trait UsersTrait
 
 
     /**
-     * Determine if the user has a group which has the required permission
+     * Determine if the user has a group which has the required permission.
      * @param $permission
      * @return bool
      */
@@ -108,12 +108,12 @@ trait UsersTrait
     {
         if (is_numeric($permission)) {
             $where = ['id', $permission];
-        } else if (is_string($permission)) {
+        } elseif (is_string($permission)) {
             $where = ['slug', $permission];
-        } else if ($permission instanceof Permission) {
+        } elseif ($permission instanceof Permission) {
             $where = ['slug', $permission->slug];
         }
-        
+
         if ($permission != null) {
             foreach ($this->groups as $group) {
                 if ($group->permissions->where(...$where)->count() > 0) {

--- a/src/Traits/UsersTrait.php
+++ b/src/Traits/UsersTrait.php
@@ -6,8 +6,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Junges\ACL\Exceptions\GroupDoesNotExistException;
 use Junges\ACL\Exceptions\PermissionDoesNotExistException;
-use Junges\ACL\Http\Models\Permission;
-use Junges\ACL\Http\Models\Group;
 
 trait UsersTrait
 {
@@ -38,15 +36,18 @@ trait UsersTrait
      */
     public function hasGroup($group)
     {
+        $model = app(config('acl.models.group'));
+        $where = null;
+
         if (is_numeric($group)) {
             $where = ['id', $group];
         } elseif (is_string($group)) {
             $where = ['slug', $group];
-        } elseif ($group instanceof Group) {
+        } elseif ($group instanceof $model) {
             $where = ['slug', $group->slug];
         }
 
-        if ($group != null) {
+        if ($group != null && $where != null) {
             return null !== $this->groups->where(...$where)->first();
         }
 
@@ -60,15 +61,18 @@ trait UsersTrait
      */
     public function hasPermission($permission)
     {
+        $model = app(config('acl.models.permission'));
+        $where = null;
+
         if (is_numeric($permission)) {
             $where = ['id', $permission];
         } elseif (is_string($permission)) {
             $where = ['slug', $permission];
-        } elseif ($permission instanceof Permission) {
+        } elseif ($permission instanceof $model) {
             $where = ['slug', $permission->slug];
         }
 
-        if ($permission != null) {
+        if ($permission != null && $where != null) {
             return (bool) ($this->permissions->where(...$where)->count())
                 || $this->hasPermissionThroughGroup($permission);
         }
@@ -83,15 +87,18 @@ trait UsersTrait
      */
     public function hasDirectPermission($permission)
     {
+        $model = app(config('acl.models.permission'));
+        $where = null;
+
         if (is_numeric($permission)) {
             $where = ['id', $permission];
         } elseif (is_string($permission)) {
             $where = ['slug', $permission];
-        } elseif ($permission instanceof Permission) {
+        } elseif ($permission instanceof $model) {
             $where = ['slug', $permission->slug];
         }
         
-        if ($permission != null) {
+        if ($permission != null && $where != null) {
             return (bool) ($this->permissions->where(...$where)->count());
         }
 
@@ -106,15 +113,18 @@ trait UsersTrait
      */
     public function hasPermissionThroughGroup($permission)
     {
+        $model = app(config('acl.models.permission'));
+        $where = null;
+
         if (is_numeric($permission)) {
             $where = ['id', $permission];
         } elseif (is_string($permission)) {
             $where = ['slug', $permission];
-        } elseif ($permission instanceof Permission) {
+        } elseif ($permission instanceof $model) {
             $where = ['slug', $permission->slug];
         }
 
-        if ($permission != null) {
+        if ($permission != null && $where != null) {
             foreach ($this->groups as $group) {
                 if ($group->permissions->where(...$where)->count() > 0) {
                     return true;


### PR DESCRIPTION
The `has` methods now use eager loaded Groups & Permissions.
These methods are heavily used in blade via their respective directives - this is why they should rely on eager loaded relationships when preforming checks.
Related to #112 